### PR TITLE
Removed autopatching of urlconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ And add `debug_informer` to your `INSTALLED_APPS` setting:
         'debug_informer',
     )
 
+Include the application urls into your project root urlconf:
+
+    urlpatterns = patterns('',
+        # ...
+        url(r'^djdi/', include('debug_informer.urls', namespace='djdi')),
+    )
+
 Enjoy!
 
 # Usage

--- a/debug_informer/apps.py
+++ b/debug_informer/apps.py
@@ -3,8 +3,6 @@
 from django.apps import AppConfig
 from django.utils.translation import ugettext_lazy as _
 
-from debug_informer import settings as di_settings
-
 __all__ = (
     'DebugInformerConfig',
 )
@@ -13,9 +11,3 @@ __all__ = (
 class DebugInformerConfig(AppConfig):
     name = 'debug_informer'
     verbose_name = _('Debug Informer')
-
-    def ready(self):
-        if not di_settings.PATCH_SETTINGS:
-            return
-
-        di_settings.patch_all()

--- a/debug_informer/settings.py
+++ b/debug_informer/settings.py
@@ -9,8 +9,6 @@ from django.conf import settings
 
 __all__ = (
     'PATCH_SETTINGS',
-
-    'patch_all',
 )
 
 
@@ -26,18 +24,3 @@ CONFIG.update(USER_CONFIG)
 PATCH_SETTINGS = getattr(
     settings, 'DEBUG_INFORMER_PATCH_SETTINGS', settings.DEBUG
 )
-
-
-def patch_all():
-    patch_root_urlconf()
-
-
-def patch_root_urlconf():
-    from django.conf.urls import include, url
-    from django.core.urlresolvers import clear_url_caches
-
-    urlconf_module = import_module(settings.ROOT_URLCONF)
-    urlconf_module.urlpatterns = [
-        url(r'^djdi/', include('debug_informer.urls', namespace='djdi')),
-    ] + urlconf_module.urlpatterns
-    clear_url_caches()


### PR DESCRIPTION
The reason is it only worked in Django versions supporting AppConfig (1.7 and newer)
and is rather hard to test if we decide to create some workaround for older Django versions.
Asking the user to include urls into his urlconf manually seems to be the easiest option.
When doing so the user gets the ability to include that urls to whatever location he wants,
this was also impossible with auto-patching. Well, not quite impossible but requiring some amount of work.